### PR TITLE
Read binary PUZ files

### DIFF
--- a/files.js
+++ b/files.js
@@ -13,8 +13,71 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
+class PuzReader {
+  constructor(buf) {
+    this.buf = buf;
+  }
+
+  readShort(ix) {
+    return this.buf[ix] | (this.buf[ix + 1] << 8);
+  }
+
+  readString() {
+    let result = [];
+    while (true) {
+      let c = this.buf[this.ix++];
+      if (c == 0) break;
+      result.push(String.fromCodePoint(c));
+    }
+    return result.join('');
+  }
+
+  toJson() {
+    let json = {};
+    let w = this.buf[0x2c];
+    let h = this.buf[0x2d];
+    json.size = {cols: w, rows: h};
+    let grid = [];
+    for (var i = 0; i < w * h; i++) {
+      grid.push(String.fromCodePoint(this.buf[0x34 + i]));
+    }
+    json.grid = grid;
+    this.ix = 0x34 + 2 * w * h;
+    json.title = this.readString();
+    json.author = this.readString();
+    json.copyright = this.readString();
+    var across = [];
+    var down = [];
+    var label = 1;
+    for (var i = 0; i < w * h; i++) {
+      if (grid[i] == '.') continue;
+      var inc = 0;
+      if (i % w == 0 || grid[i - 1] == '.') {
+        across.push(label + ". " + this.readString());
+        inc = 1;
+      }
+      if (i < w || grid[i - w] == '.') {
+        down.push(label + ". " + this.readString());
+        inc = 1;
+      }
+      label += inc;
+    }
+    json.clues = {across: across, down: down};
+    console.log(json);
+    return json;
+  }
+}
+
 function openPuzzle() {
   document.getElementById("open-puzzle-input").click();
+}
+
+function isPuz(bytes) {
+  const magic = 'ACROSS&DOWN';
+  for (var i = 0; i < magic.length; i++) {
+    if (bytes[2 + i] != magic.charCodeAt(i)) return false;
+  }
+  return bytes[2 + magic.length] == 0;
 }
 
 function openJSONFile(e) {
@@ -25,7 +88,14 @@ function openJSONFile(e) {
   let reader = new FileReader();
   reader.onload = function(e) {
     try {
-      const puz = JSON.parse(e.target.result);
+      const bytes = new Uint8Array(e.target.result);
+      let puz;
+      if (isPuz(bytes)) {
+        puz = new PuzReader(bytes).toJson();
+      } else {
+        // Note: TextDecoder doesn't work in Edge 16
+        puz = JSON.parse(new TextDecoder().decode(bytes));
+      }
       convertJSONToPuzzle(puz);
       console.log("Loaded puzzle.");
     }
@@ -36,7 +106,7 @@ function openJSONFile(e) {
       }
     }
   };
-  reader.readAsText(file);
+  reader.readAsArrayBuffer(file);
 }
 
 function convertJSONToPuzzle(puz) {

--- a/files.js
+++ b/files.js
@@ -13,6 +13,11 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
+function ScrambledError() {
+   this.message = 'Cannot open scrambled Across Lite files';
+   this.name = 'ScrambledError';
+}
+
 class PuzReader {
   constructor(buf) {
     this.buf = buf;
@@ -36,6 +41,10 @@ class PuzReader {
     let json = {};
     let w = this.buf[0x2c];
     let h = this.buf[0x2d];
+    let scrambled = this.readShort(0x32);
+    if (scrambled & 0x0004) {
+      throw new ScrambledError;
+    }
     json.size = {cols: w, rows: h};
     let grid = [];
     for (var i = 0; i < w * h; i++) {
@@ -103,6 +112,10 @@ function openJSONFile(e) {
       if (err.name == "SyntaxError") {
         window.alert("Invalid puzzle file. Try a .xw (or any JSON) puzzle.");
         return;
+      } else if (err.name == "ScrambledError") {
+        window.alert("Cannot open scrambled Across Lite files.")
+      } else {
+        console.log("Unknown error", err);
       }
     }
   };

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <button id="open-JSON" type="button" data-tooltip="Open puzzle..." onclick="openPuzzle()">
       <i class="fa fa-folder-open-o fa-fw" aria-hidden="true"></i>
     </button>
-    <input id="open-puzzle-input" type="file" accept=".json,.txt,.xw"/>
+    <input id="open-puzzle-input" type="file" accept=".json,.txt,.xw,.puz"/>
     <button id="export-JSON" type="button" data-tooltip="Save puzzle" onclick="writeJSONFile()">
       <i class="fa fa-download fa-fw" aria-hidden="true"></i>
     </button>


### PR DESCRIPTION
Adds support for reading files in binary PUZ (Across Lite) format. No UI work is needed as it auto-detects the file format on load.

Note that this uses the TextDecoder API, which has been around a couple of years but not yet supported on Edge.