### PR TITLE
cross.js: get clues via textContent instead of innerHTML to avoid HTML encoding and stray html tags

### DIFF
--- a/cross.js
+++ b/cross.js
@@ -656,8 +656,8 @@ function updateSidebarHighlights() {
 }
 
 function setClues() {
-    xw.clues[[current.row, current.acrossStartIndex, ACROSS]] = document.getElementById("across-clue-text").innerHTML;
-    xw.clues[[current.downStartIndex, current.col, DOWN]] = document.getElementById("down-clue-text").innerHTML;
+    xw.clues[[current.row, current.acrossStartIndex, ACROSS]] = document.getElementById("across-clue-text").textContent;
+    xw.clues[[current.downStartIndex, current.col, DOWN]] = document.getElementById("down-clue-text").textContent;
     // console.log("Stored clue:", xw.clues[[current.row, current.acrossStartIndex, ACROSS]], "at [" + current.row + "," + current.acrossStartIndex + "]");
     // console.log("Stored clue:", xw.clues[[current.downStartIndex, current.col, DOWN]], "at [" + current.downStartIndex + "," + current.col + "]");
 }


### PR DESCRIPTION
👋what an excellent project!

Dropping this PR here because I was getting annoyed by clues exporting as
> "Law &amp; Order" spinoff, briefly

and also it seemed that any stray HTML tags that ended up in a clue due to copy-paste being impossible to get rid of.

Couldn't test it very thoroughly because I ran into [problems generating xwsolve.js](https://xkcd.com/1987/) and gave up, but I think this does the trick.