### PR TITLE
Across and down blocks of length one no longer treated as across or down clues.

### DIFF
--- a/cross.js
+++ b/cross.js
@@ -534,13 +534,13 @@ function createGrid(rows, cols) {
 
 function updateLabelsAndClues() {
   let count = 1;
-  for (let i = 0; i < xw.rows; i++) {
-    for (let j = 0; j < xw.cols; j++) {
+  for (let i = 0; i < xw.rows - 1; i++) {
+    for (let j = 0; j < xw.cols - 1; j++) {
       let isAcross = false;
       let isDown = false;
       if (xw.fill[i][j] != BLACK) {
-        isDown = i == 0 || xw.fill[i - 1][j] == BLACK;
-        isAcross = j == 0 || xw.fill[i][j - 1] == BLACK;
+        isDown = (i == 0 || xw.fill[i - 1][j] == BLACK) && xw.fill[i + 1][j] != BLACK;
+        isAcross = (j == 0 || xw.fill[i][j - 1] == BLACK) && xw.fill[i][j + 1] != BLACK;
       }
       const grid = document.getElementById("grid");
       let currentCell = grid.querySelector('[data-row="' + i + '"]').querySelector('[data-col="' + j + '"]');

--- a/cross.js
+++ b/cross.js
@@ -534,16 +534,26 @@ function createGrid(rows, cols) {
 
 function updateLabelsAndClues() {
   let count = 1;
-  for (let i = 0; i < xw.rows - 1; i++) {
-    for (let j = 0; j < xw.cols - 1; j++) {
+  for (let i = 0; i < xw.rows; i++) {
+    for (let j = 0; j < xw.cols; j++) {
+
       let isAcross = false;
       let isDown = false;
+
       if (xw.fill[i][j] != BLACK) {
-        isDown = (i == 0 || xw.fill[i - 1][j] == BLACK) && xw.fill[i + 1][j] != BLACK;
-        isAcross = (j == 0 || xw.fill[i][j - 1] == BLACK) && xw.fill[i][j + 1] != BLACK;
+        if (i == xw.rows - 1) {
+          isAcross = j == 0 || xw.fill[i][j - 1] == BLACK;
+        } else if (j == xw.cols - 1) {
+          isDown = i == 0 || xw.fill[i - 1][j] == BLACK;
+        } else {
+          isDown = (i == 0 || xw.fill[i - 1][j] == BLACK) && xw.fill[i + 1][j] != BLACK;
+          isAcross = (j == 0 || xw.fill[i][j - 1] == BLACK) && xw.fill[i][j + 1] != BLACK;
+        }
       }
+
       const grid = document.getElementById("grid");
       let currentCell = grid.querySelector('[data-row="' + i + '"]').querySelector('[data-col="' + j + '"]');
+
       if (isAcross || isDown) {
         currentCell.firstChild.innerHTML = count; // Set square's label to the count
         count++;


### PR DESCRIPTION
Modified the cross.js file slightly so that I could use Phil Crossword to write cryptic style crosswords without down clues and labels being generated for each square in a single across clue, and vice versa. 

Achieved this by updating the IsAcross and IsDown conditions in the UpdateLabelsAndClues function in cross.js (line 535) to loop to the second last index in each row and column (the last index will never be a valid clue) and adding a check for the following square in the row not being filled black. Have tested it extensively and no other functionality in the app is broken by this change.

Before:

<img width="584" alt="Screenshot 2023-07-09 at 13 37 07" src="https://github.com/keiranking/Phil/assets/22524591/8cc22665-0bff-47b9-af5b-2f76a6b80cea">

_For the purposes of creating an english-style cryptic grid I couldn't use Phil Crossword, as it generated invalid labels and clues_

After: 

<img width="583" alt="Screenshot 2023-07-10 at 18 13 30" src="https://github.com/keiranking/Phil/assets/22524591/92e99454-9eb3-4cc2-a735-bba27db2abd9">

_Phil Crossword now works for my purposes, and doesn't generate labels or clues that have a length of one_



